### PR TITLE
Rewrite get_mtx_metadata()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -97,6 +97,18 @@ map_memory_to_disk_logical_matrix <- function(file_name_in, m_cell_idxs, cell_id
     invisible(.Call(`_ondisc_map_memory_to_disk_logical_matrix`, file_name_in, m_cell_idxs, cell_idxs_name, n_features, m_row_ptr, f_row_ptr))
 }
 
+#' Get mtx metadata
+#'
+#' @param mtx_fp path to the mtx file
+#'
+#' @return a list containing (i) n_genes, (ii) n_cells, (iii) the number of
+#'     data points (i.e., fraction of entries that are zero),
+#'     (iv) (TRUE/FALSE) matrix is logical
+#' @noRd
+get_mtx_metadata <- function(mtx_fp) {
+    .Call(`_ondisc_get_mtx_metadata`, mtx_fp)
+}
+
 #' @title decrement a vector of indexes
 #' @param idxs an integer vector of indexes
 #' @noRd

--- a/R/high_level_initialize.R
+++ b/R/high_level_initialize.R
@@ -51,8 +51,7 @@ create_ondisc_matrix_from_mtx <- function(mtx_fp, barcodes_fp, features_fp, n_li
   bag_of_variables <- new.env()
 
   # extract .mtx metadata
-  n_rows_with_comments <- get_n_rows_with_comments_mtx(mtx_fp)
-  mtx_metadata <- get_mtx_metadata(mtx_fp, n_rows_with_comments)
+  mtx_metadata <- get_mtx_metadata(mtx_fp)
   bag_of_variables[[arguments_enum()$n_cells]] <- mtx_metadata$n_cells
   bag_of_variables[[arguments_enum()$n_features]] <- mtx_metadata$n_features
 
@@ -77,7 +76,7 @@ create_ondisc_matrix_from_mtx <- function(mtx_fp, barcodes_fp, features_fp, n_li
 
   # Get number of elements to load per chunk
   is_logical <- mtx_metadata$is_logical
-  n_rows_to_skip <- n_rows_with_comments + 1
+  n_rows_to_skip <- mtx_metadata$n_rows_to_skip
 
   # Run core algorithm
   out <- run_core_mtx_algo(h5_fp, mtx_fp, is_logical, covariates, bag_of_variables, n_lines_per_chunk, n_rows_to_skip, progress)

--- a/R/high_level_initialize_helper.R
+++ b/R/high_level_initialize_helper.R
@@ -1,22 +1,3 @@
-#' Get mtx metadata
-#'
-#' @param mtx_fp filepath to the mtx file
-#' @param n_rows_with_comments number of rows with comments (at top of file)
-#'
-#' @return a list containing (i) n_genes, (ii) n_cells, (iii) the numer of data points (i.e., fraction of entries that are zero), (iv) (TRUE/FALSE) matrix is logical
-#' @noRd
-get_mtx_metadata <- function(mtx_fp, n_rows_with_comments) {
-  metadata <- utils::read.table(file = mtx_fp, nrows = 1, skip = n_rows_with_comments, header = FALSE, sep = " ", colClasses = c("integer", "integer", "integer"))
-  n_features <- metadata %>% dplyr::pull(1)
-  n_cells <- metadata %>% dplyr::pull(2)
-  n_data_points <- metadata %>% dplyr::pull(3)
-  if (n_data_points > .Machine$integer.max) stop("Numer of rows exceeds maximum value.")
-  first_row <- utils::read.table(file = mtx_fp, nrows = 1, skip = n_rows_with_comments + 1, header = FALSE, sep = " ", colClasses = "integer")
-  is_logical <- ncol(first_row) == 2
-  return(list(n_features = n_features, n_cells = n_cells, n_data_points = n_data_points, is_logical = is_logical))
-}
-
-
 #' Get metadata for features.tsv file
 #'
 #' Gets metadata from a features.tsv file. As a side-effect, if MT genes are present, puts into the bag_of_variables a logical vector indicating the positions of those genes.
@@ -77,25 +58,4 @@ generate_on_disc_matrix_name <- function(on_disc_dir) {
 read_given_column_of_tsv <- function(col_idx, n_cols, tsv_file, progress = FALSE) {
   type_pattern <- c(rep("_", col_idx - 1), "c", rep("_", n_cols - col_idx)) %>% paste0(collapse = "")
   dplyr::pull(readr::read_tsv(file = tsv_file, col_names = FALSE, col_types = type_pattern, progress = progress))
-}
-
-
-#' get n rows with comments mtx
-#'
-#' @param mtx_fp file path to mtx
-#'
-#' @return the number of rows in the mtx with comments
-#' @noRd
-get_n_rows_with_comments_mtx <- function(mtx_fp) {
-  n_rows_with_comments <- 0
-  repeat {
-    curr_row <- utils::read.table(mtx_fp, nrows = 1, skip = n_rows_with_comments, header = FALSE, sep = "\n") %>% dplyr::pull()
-    is_comment <- substr(curr_row, start = 1, stop = 1) == "%"
-    if (!is_comment) {
-      break()
-    } else {
-      n_rows_with_comments <- n_rows_with_comments + 1
-    }
-  }
-  return(n_rows_with_comments)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -129,6 +129,17 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// get_mtx_metadata
+List get_mtx_metadata(CharacterVector mtx_fp);
+RcppExport SEXP _ondisc_get_mtx_metadata(SEXP mtx_fpSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< CharacterVector >::type mtx_fp(mtx_fpSEXP);
+    rcpp_result_gen = Rcpp::wrap(get_mtx_metadata(mtx_fp));
+    return rcpp_result_gen;
+END_RCPP
+}
 // decrement_idxs
 void decrement_idxs(IntegerVector idxs);
 RcppExport SEXP _ondisc_decrement_idxs(SEXP idxsSEXP) {
@@ -161,6 +172,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_ondisc_write_data_h5", (DL_FUNC) &_ondisc_write_data_h5, 4},
     {"_ondisc_map_memory_to_disk", (DL_FUNC) &_ondisc_map_memory_to_disk, 8},
     {"_ondisc_map_memory_to_disk_logical_matrix", (DL_FUNC) &_ondisc_map_memory_to_disk_logical_matrix, 6},
+    {"_ondisc_get_mtx_metadata", (DL_FUNC) &_ondisc_get_mtx_metadata, 1},
     {"_ondisc_decrement_idxs", (DL_FUNC) &_ondisc_decrement_idxs, 1},
     {"_ondisc_sum_in_place", (DL_FUNC) &_ondisc_sum_in_place, 2},
     {NULL, NULL, 0}

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1,0 +1,73 @@
+#include <Rcpp.h>
+#include <fstream>
+#include <sstream>
+
+using Rcpp::CharacterVector;
+using Rcpp::List;
+
+//' Get mtx metadata
+//'
+//' @param mtx_fp path to the mtx file
+//'
+//' @return a list containing (i) n_genes, (ii) n_cells, (iii) the number of
+//'     data points (i.e., fraction of entries that are zero),
+//'     (iv) (TRUE/FALSE) matrix is logical
+//' @noRd
+// [[Rcpp::export]]
+List get_mtx_metadata(CharacterVector mtx_fp)
+{
+  // Convert to C++ string
+  std::string path = Rcpp::as<std::string>(mtx_fp);
+  // Open file
+  std::ifstream file(path);
+  if(!file.is_open())
+    Rcpp::stop("cannot open file '" + path + "'");
+
+  // Find the first line that does not begin with "%"
+  std::string line;
+  int n_features = 0, n_cells = 0, n_data_points = 0, n_rows_to_skip = 0;
+  // The return value of std::getline evaluates to be true
+  // if a line is read successfully
+  while(std::getline(file, line))
+  {
+    if(line[0] != '%')
+    {
+      // The first line that does not begin with "%" has the format
+      //   rows columns num_of_nonzeros
+      std::stringstream ss(line);
+      ss >> n_features >> n_cells >> n_data_points;
+      // Also skip this line
+      n_rows_to_skip++;
+      break;
+    } else{
+      // Skip this line if it is a comment
+      n_rows_to_skip++;
+    }
+  }
+
+  // Largest number of data points - 2147483647
+  const int integer_max = ~(1 << 31);
+  if(n_data_points > integer_max)
+    Rcpp::stop("Numer of rows exceeds maximum value.");
+
+  bool is_logical = false;
+  // Read the first data line
+  if(std::getline(file, line))
+  {
+    std::stringstream ss(line);
+    int i, j, x;
+    // Test whether there are three values
+    bool status = bool(ss >> i >> j >> x);
+    // If status is false, it means there are only two values,
+    // indicating a logical matrix
+    is_logical = !status;
+  }
+
+  return List::create(
+    Rcpp::Named("n_features")     = n_features,
+    Rcpp::Named("n_cells")        = n_cells,
+    Rcpp::Named("n_data_points")  = n_data_points,
+    Rcpp::Named("is_logical")     = is_logical,
+    Rcpp::Named("n_rows_to_skip") = n_rows_to_skip
+  );
+}

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -11,7 +11,8 @@ using Rcpp::List;
 //'
 //' @return a list containing (i) n_genes, (ii) n_cells, (iii) the number of
 //'     data points (i.e., fraction of entries that are zero),
-//'     (iv) (TRUE/FALSE) matrix is logical
+//'     (iv) (TRUE/FALSE) matrix is logical,
+//'     (v) number of rows to skip before reading the data
 //' @noRd
 // [[Rcpp::export]]
 List get_mtx_metadata(CharacterVector mtx_fp)


### PR DESCRIPTION
This PR rewrites the `get_mtx_metadata()` function in a cleaner and more efficient way. It encapsulates the previous `get_n_rows_with_comments_mtx()` and `get_mtx_metadata()` functions into a single one, and only reads the data file once.

There is one more tiny issue. In the previous R code of `get_mtx_metadata()`, an error is given if `n_data_points > .Machine$integer.max`. However, the error message says "Numer of rows exceeds maximum value", so it needs to be clarified whether we put the limit on `n_data_points`, or `n_features`, or `n_cells`.