### PR TITLE
Some tweaks

### DIFF
--- a/R/high_level_initialize.R
+++ b/R/high_level_initialize.R
@@ -57,8 +57,8 @@ create_ondisc_matrix_from_mtx <- function(mtx_fp, barcodes_fp, features_fp, n_li
 
   # extract features.tsv metadata; as a side-effect, if there are MT genes, put the locations of those genes into the bag_of_vars.
   features_metadata <- get_features_metadata(features_fp, bag_of_variables)
-  # set the on_disk_dir, if necessary
-  if (is.null(on_disk_dir)) on_disk_dir <- gsub(pattern = '/[^/]*$', replacement = "", x = mtx_fp)
+  # Set the on_disk_dir, if necessary
+  if (is.null(on_disk_dir)) on_disk_dir <- dirname(mtx_fp)
 
   # Generate a name for the ondisc_matrix .h5 file, if necessary
   if (is.null(file_name)) {
@@ -66,7 +66,7 @@ create_ondisc_matrix_from_mtx <- function(mtx_fp, barcodes_fp, features_fp, n_li
   } else {
     if (!grepl(pattern = "*.h5$", x = file_name)) file_name <- paste0(file_name, ".h5")
   }
-  h5_fp <- paste0(on_disk_dir, "/", file_name)
+  h5_fp <- file.path(on_disk_dir, file_name)
 
   # Initialize the .h5 file on-disk (side-effect)
   initialize_h5_file_on_disk(h5_fp, mtx_metadata, features_metadata, barcodes_fp, features_fp, progress)

--- a/R/high_level_initialize.R
+++ b/R/high_level_initialize.R
@@ -50,12 +50,12 @@ create_ondisc_matrix_from_mtx <- function(mtx_fp, barcodes_fp, features_fp, n_li
   # Define "bag_of_variables" environment for storing args
   bag_of_variables <- new.env()
 
-  # extract .mtx metadata
+  # Extract .mtx metadata
   mtx_metadata <- get_mtx_metadata(mtx_fp)
   bag_of_variables[[arguments_enum()$n_cells]] <- mtx_metadata$n_cells
   bag_of_variables[[arguments_enum()$n_features]] <- mtx_metadata$n_features
 
-  # extract features.tsv metadata; as a side-effect, if there are MT genes, put the locations of those genes into the bag_of_vars.
+  # Extract features.tsv metadata; as a side-effect, if there are MT genes, put the locations of those genes into the bag_of_vars.
   features_metadata <- get_features_metadata(features_fp, bag_of_variables)
   # Set the on_disk_dir, if necessary
   if (is.null(on_disk_dir)) on_disk_dir <- dirname(mtx_fp)
@@ -84,8 +84,8 @@ create_ondisc_matrix_from_mtx <- function(mtx_fp, barcodes_fp, features_fp, n_li
   out$ondisc_matrix <- odm
   if (return_metadata_ondisc_matrix) {
     out <- metadata_ondisc_matrix(ondisc_matrix = out$ondisc_matrix,
-                                   cell_covariates = out$cell_covariates,
-                                   feature_covariates = out$feature_covariates)
+                                  cell_covariates = out$cell_covariates,
+                                  feature_covariates = out$feature_covariates)
   }
   return(out)
 }

--- a/R/high_level_initialize.R
+++ b/R/high_level_initialize.R
@@ -64,7 +64,7 @@ create_ondisc_matrix_from_mtx <- function(mtx_fp, barcodes_fp, features_fp, n_li
   if (is.null(file_name)) {
     file_name <- generate_on_disc_matrix_name(on_disk_dir)
   } else {
-    if (!grepl(pattern = "*.h5$", x = file_name)) file_name <- paste0(file_name, ".h5")
+    if (!grepl(pattern = "*\\.h5$", x = file_name)) file_name <- paste0(file_name, ".h5")
   }
   h5_fp <- file.path(on_disk_dir, file_name)
 

--- a/R/high_level_initialize_helper.R
+++ b/R/high_level_initialize_helper.R
@@ -26,20 +26,22 @@ get_features_metadata <- function(features_fp, bag_of_variables) {
 
 #' Generate on disc_matrix_name
 #'
-#' Generates the name of an on_disc_matrix object given a directory. This function searches for files named on_disc_matrix_x.h5 in the specified directory. If none exists, it returns on_disc_matrix_1.h5. Else, it returns n_disc_matrix_x.h5 with a unique integer in place of x.
+#' Generates the name of an on_disc_matrix object given a directory.
+#' This function searches for files named on_disc_matrix_<id>.h5 in the specified directory.
+#' If none exists, it returns on_disc_matrix_1.h5. Else, it returns n_disc_matrix_<id>.h5
+#' with a unique integer in place of <id>.
 #'
 #' @param on_disc_dir directory in which to store the on_disc_matrix.
 #' @return a new name for an on_disc_matrix.
 #' @noRd
 generate_on_disc_matrix_name <- function(on_disc_dir) {
-  fs <- list.files(on_disc_dir)
+  # Only list ondisc_matrix_<id>.h5 files
   base_name <- "ondisc_matrix_"
-  idxs <- grep(pattern = paste0(base_name, "[0-9]+.h5"), x = fs)
-  if (length(idxs) == 0) {
+  fs <- list.files(on_disc_dir, pattern = paste0(base_name, "[0-9]+\\.h5"))
+  if (length(fs) == 0) {
     name <- paste0(base_name, "1.h5")
   } else {
-    existing_names <- fs[idxs]
-    ints_in_use <- gsub(pattern = paste0(base_name, "(\\d+).h5"), replacement = "\\1", x = existing_names) %>% as.integer()
+    ints_in_use <- gsub(pattern = paste0(base_name, "(\\d+)\\.h5"), replacement = "\\1", x = fs) %>% as.integer()
     new_int <- max(ints_in_use) + 1
     name <- paste0(base_name, new_int, ".h5")
   }

--- a/R/low_level_initialize.R
+++ b/R/low_level_initialize.R
@@ -12,7 +12,10 @@
 #' @noRd
 initialize_h5_file_on_disk <- function(h5_fp, mtx_metadata, features_metadata, barcodes_fp, features_fp, progress) {
   # Create the .h5 file
-  rhdf5::h5createFile(h5_fp) %>% invisible()
+  status <- rhdf5::h5createFile(h5_fp)
+  if(!status)
+    stop(sprintf("Creating %s failed", h5_fp))
+
   # Write metadata
   cell_barcodes <- dplyr::pull(readr::read_tsv(file = barcodes_fp, col_names = FALSE, col_types = "c", progress = progress))
   rhdf5::h5write(cell_barcodes, h5_fp, "cell_barcodes")
@@ -26,19 +29,20 @@ initialize_h5_file_on_disk <- function(h5_fp, mtx_metadata, features_metadata, b
   rhdf5::h5write(mtx_metadata$is_logical, h5_fp, "logical_mat")
 
   # Initialize CSC
-  rhdf5::h5createDataset(file = h5_fp, dataset = "cell_ptr", dims = mtx_metadata$n_cells + 1, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_cells, 10)) %>% invisible()
-  rhdf5::h5createDataset(file = h5_fp, dataset = "feature_idxs", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50)) %>% invisible()
+  rhdf5::h5createDataset(file = h5_fp, dataset = "cell_ptr", dims = mtx_metadata$n_cells + 1, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_cells, 10))
+  rhdf5::h5createDataset(file = h5_fp, dataset = "feature_idxs", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50))
   if (!mtx_metadata$is_logical) {
-  rhdf5::h5createDataset(file = h5_fp, dataset = "data_csc", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50)) %>% invisible()
+    rhdf5::h5createDataset(file = h5_fp, dataset = "data_csc", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50))
   }
 
   # Initialize CSR
-  rhdf5::h5createDataset(file = h5_fp, dataset = "feature_ptr", dims = mtx_metadata$n_features + 1, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_features, 10)) %>% invisible()
-  rhdf5::h5createDataset(file = h5_fp, dataset = "cell_idxs", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50)) %>% invisible()
+  rhdf5::h5createDataset(file = h5_fp, dataset = "feature_ptr", dims = mtx_metadata$n_features + 1, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_features, 10))
+  rhdf5::h5createDataset(file = h5_fp, dataset = "cell_idxs", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50))
   if (!mtx_metadata$is_logical) {
-    rhdf5::h5createDataset(file = h5_fp, dataset = "data_csr", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50)) %>% invisible()
+    rhdf5::h5createDataset(file = h5_fp, dataset = "data_csr", dims = mtx_metadata$n_data_points, storage.mode = "integer", level = 0L, chunk = min(mtx_metadata$n_data_points - 1, 50))
   }
-  return(invisible())
+
+  invisible(NULL)
 }
 
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -49,7 +49,7 @@ List get_mtx_metadata(CharacterVector mtx_fp)
   // Largest number of data points - 2147483647
   const int integer_max = ~(1 << 31);
   if(n_data_points > integer_max)
-    Rcpp::stop("Numer of rows exceeds maximum value.");
+    Rcpp::stop("Numer of data points exceeds maximum value.");
 
   bool is_logical = false;
   // Read the first data line


### PR DESCRIPTION
This PR provides some tweaks and bug fixes to existing code. For example,

1. Use system-independent functions `dirname()` and `file.path()` to replace regular expressions.
2. Use the `pattern` argument in `list.files()`.
3. Correctly escape the "." character in regular expressions. To match the ".h5" suffix, we need to use `"\\.h5$"`, not `".h5$"`.