### PR TITLE
Guard pair iteration at vector bounds

### DIFF
--- a/src/sceptre_functs.cpp
+++ b/src/sceptre_functs.cpp
@@ -71,7 +71,7 @@ List compute_nt_nonzero_matrix_and_n_ok_pairs_ondisc(const std::string& file_nam
     }
 
     // iterate through the discovery pairs containing this gene
-    while (to_analyze_response_idxs[pair_pointer] - 1 == row_idx) {
+    while (pair_pointer < n_pairs && to_analyze_response_idxs[pair_pointer] - 1 == row_idx) {
       curr_idxs = grna_group_idxs[to_analyze_grna_idxs[pair_pointer] - 1];
       curr_n_nonzero_trt = 0;
       // first, get n nonzero trt
@@ -153,7 +153,7 @@ List compute_n_ok_pairs_ondisc(const std::string& file_name_in, SEXP f_row_ptr, 
     }
 
     // iterate through the discovery pairs containing this gene
-    while (to_analyze_response_idxs[pair_pointer] - 1 == row_idx) {
+    while (pair_pointer < n_pairs && to_analyze_response_idxs[pair_pointer] - 1 == row_idx) {
       curr_idxs = grna_group_idxs[to_analyze_grna_idxs[pair_pointer] - 1];
       curr_n_nonzero_trt = 0;
       // first, get n nonzero trt

--- a/tests/testthat/test-sceptre_functs.R
+++ b/tests/testthat/test-sceptre_functs.R
@@ -1,0 +1,53 @@
+test_that("pairwise QC stops at the end of pair vectors", {
+  matrix_in <- Matrix::Matrix(
+    matrix(c(1, 0, 0, 0, 1, 0), nrow = 2L, byrow = TRUE),
+    sparse = TRUE
+  )
+  rownames(matrix_in) <- c("gene_1", "gene_2")
+  odm_file <- tempfile(fileext = ".odm")
+  on.exit(unlink(odm_file))
+  odm <- create_odm_from_r_matrix(
+    mat = matrix_in,
+    file_to_write = odm_file,
+    chunk_size = 1L
+  )
+  row_pointer <- ondisc:::read_row_ptr(odm@h5_file, nrow(odm))
+
+  expect_silent(
+    full_result <- ondisc:::compute_nt_nonzero_matrix_and_n_ok_pairs_ondisc(
+      file_name_in = odm@h5_file,
+      f_row_ptr = row_pointer,
+      n_genes = 2L,
+      n_cells_orig = 3L,
+      n_cells_sub = 3L,
+      grna_group_idxs = list(1L),
+      indiv_nt_grna_idxs = list(1L),
+      all_nt_idxs = 2L,
+      to_analyze_response_idxs = 1L,
+      to_analyze_grna_idxs = 1L,
+      control_group_complement = TRUE,
+      cells_in_use = 1:3
+    )
+  )
+  expect_identical(full_result$n_nonzero_trt, 1L)
+  expect_identical(full_result$n_nonzero_cntrl, 0L)
+
+  expect_silent(
+    trans_result <- ondisc:::compute_n_ok_pairs_ondisc(
+      file_name_in = odm@h5_file,
+      f_row_ptr = row_pointer,
+      n_genes = 2L,
+      n_cells_orig = 3L,
+      n_cells_sub = 3L,
+      grna_group_idxs = list(1L),
+      all_nt_idxs = 2L,
+      to_analyze_response_idxs = 1L,
+      to_analyze_grna_idxs = 1L,
+      control_group_complement = TRUE,
+      cells_in_use = 1:3,
+      unique_response_idxs = 1L
+    )
+  )
+  expect_identical(trans_result$n_nonzero_trt, 1L)
+  expect_identical(trans_result$n_nonzero_cntrl, 0L)
+})


### PR DESCRIPTION
## Summary

- guard `pair_pointer` before indexing pair vectors in both on-disk pairwise-QC routines
- add a regression test that exercises both routines through a real temporary ODM

## Motivation

After the final pair is processed, `pair_pointer` equals `n_pairs`. The existing loop conditions then evaluate `to_analyze_response_idxs[pair_pointer]`, reading one element past the end of the vector and producing an Rcpp `subscript out of bounds` warning. Short-circuiting on `pair_pointer < n_pairs` prevents that invalid access without changing any valid pair computation.

This synchronizes the on-disk routines with the corresponding boundary fix already present in the in-memory `sceptre` implementation.

Addresses the out-of-bounds warning reported in Katsevich-Lab/sceptre#177. It does not address the separate Nextflow task-timeout concern discussed in that issue.

## Validation

- the new regression test emits two out-of-bounds warnings against current `main` and passes silently with this patch
- focused test: 6 passed, 0 failed or warned
- full test suite: 156 passed, 0 failed or warned
- independently reviewed with no actionable findings
